### PR TITLE
fix: parse resourcePart correctly when there is no qualifier

### DIFF
--- a/src/Arn.ts
+++ b/src/Arn.ts
@@ -55,7 +55,7 @@ export class InvalidArnError extends Error {
 }
 
 function parseResourcePart(resourcePart: string): ArnResource {
-  const parts = resourcePart.match(/^(.+?):(.+?):(.+)$/) || resourcePart.match(/^([^:\/]+)[\/|:](.+)$/);
+  const parts = resourcePart.match(/^(.+?):(.+?):(.+)$/) || resourcePart.match(/^([^:\/]+)[\/:](.+)$/);
 
   if (parts) {
     const [, type, id, qualifier] = parts;

--- a/src/Arn.ts
+++ b/src/Arn.ts
@@ -55,7 +55,7 @@ export class InvalidArnError extends Error {
 }
 
 function parseResourcePart(resourcePart: string): ArnResource {
-  const parts = resourcePart.match(/^([^:/]+)\/(.+)$/) || resourcePart.match(/^(.+?):(.+?):(.+)$/);
+  const parts = resourcePart.match(/^(.+?):(.+?):(.+)$/) || resourcePart.match(/^([^:\/]+)[\/|:](.+)$/);
 
   if (parts) {
     const [, type, id, qualifier] = parts;

--- a/test/Arn.test.ts
+++ b/test/Arn.test.ts
@@ -47,6 +47,28 @@ describe('ARN tests', () => {
     expect(arn.format()).to.eql(s);
   });
 
+  it('should parse an ARN with a : separated resource part without a qualifier', () => {
+    const s = 'aws:arn:lambda:eu-west-1:123456789:function:my-function-name';
+    const arn = Arn.parse(s, true);
+
+    expect(arn).to.eql({
+      scheme: 'aws',
+      partition: 'arn',
+      service: 'lambda',
+      region: 'eu-west-1',
+      accountId: '123456789',
+      resourcePart: 'function:my-function-name'
+    });
+
+    expect(arn.resource).to.eql({
+      type: 'function',
+      id: 'my-function-name',
+      qualifier: undefined,
+    });
+
+    expect(arn.format()).to.eql(s);
+  });
+
   it('should keep the parsed resource in sync if mutating resourcePart', () => {
     const arn = Arn.parse('aws:arn:lambda:eu-west-1:123456789:Layer:my-layer:42') ||
         expect.fail('Could not parse ARN');


### PR DESCRIPTION
There's an issue parsing the resourcePart of an ARN like `aws:arn:lambda:eu-west-1:123456789:function:my-function-name` where there is no qualifier at the end of the ARN.

--

```
const arn = Arn.parse("aws:arn:lambda:eu-west-1:123456789:function:my-function-name", true);
console.log(arn.resource);
```

Output: `{ id: 'function:my-function-name' }`

Expectation: `{ type: 'function', id: 'my-function-name', qualifier: undefined }`

--

The diff looks like I'm completely changing the regex, but here's are the exact changes:

- Change the first regex from `/^([^:/]+)\/(.+)$/` -> `/^([^:\/]+)[\/:](.+)$/` for two reasons:
    - Fix a minor issue by escaping the `/` in `[^:/]`.
    - Change the `\/` separator in the middle of the regex to `[\/:]` so that both `/` and `:` can be valid separators.
- Swap the order of the two regexes so the 2nd regex is now the 1st.

Lastly, added a test for the lambda case.